### PR TITLE
Execute rule and redemption callprefix-es are out of sync.

### DIFF
--- a/contracts/token/TokenHolder.sol
+++ b/contracts/token/TokenHolder.sol
@@ -93,13 +93,13 @@ contract TokenHolder is MasterCopyNonUpgradable
 
     bytes4 public constant EXECUTE_RULE_CALLPREFIX = bytes4(
         keccak256(
-            "executeRule(address,bytes,uint256,uint8,bytes32,bytes32)"
+            "executeRule(address,bytes,uint256,bytes32,bytes32,uint8)"
         )
     );
 
     bytes4 public constant EXECUTE_REDEMPTION_CALLPREFIX = bytes4(
         keccak256(
-            "executeRedemption(address,bytes,uint256,uint8,bytes32,bytes32)"
+            "executeRedemption(address,bytes,uint256,bytes32,bytes32,uint8)"
         )
     );
 

--- a/test/token_holder/execute_redemption.js
+++ b/test/token_holder/execute_redemption.js
@@ -45,13 +45,13 @@ function generateTokenHolderexecuteRedemptionFunctionCallPrefix() {
         type: 'uint256', name: '',
       },
       {
+        type: 'bytes32', name: '',
+      },
+      {
+        type: 'bytes32', name: '',
+      },
+      {
         type: 'uint8', name: '',
-      },
-      {
-        type: 'bytes32', name: '',
-      },
-      {
-        type: 'bytes32', name: '',
       },
     ],
   });

--- a/test/token_holder/execute_rule.js
+++ b/test/token_holder/execute_rule.js
@@ -139,13 +139,13 @@ function generateTokenHolderExecuteRuleCallPrefix() {
         type: 'uint256', name: '',
       },
       {
+        type: 'bytes32', name: '',
+      },
+      {
+        type: 'bytes32', name: '',
+      },
+      {
         type: 'uint8', name: '',
-      },
-      {
-        type: 'bytes32', name: '',
-      },
-      {
-        type: 'bytes32', name: '',
       },
     ],
   });


### PR DESCRIPTION
Execute rule and redemption callprefix-es are out of sync with corresponding functions' signatures.

Fixes #179