### PR TITLE
Test to verify call prefixes

### DIFF
--- a/test/test_lib/utils.js
+++ b/test/test_lib/utils.js
@@ -171,15 +171,16 @@ module.exports = {
     const contract = artifacts.require(contractName);
 
     let methodConcat = methodName.concat('(');
-    let input, abiMethod;
+    let input;
+    let abiMethod;
 
-    for(let i = 0; i < contract.abi.length; i++) {
+    for (let i = 0; i < contract.abi.length; i += 1) {
       abiMethod = contract.abi[i];
-      if(abiMethod.name === methodName) {
-        for(let j=0; j < abiMethod.inputs.length - 1; j ++) {
+      if (abiMethod.name === methodName) {
+        for (let j = 0; j < abiMethod.inputs.length - 1; j += 1) {
           input = abiMethod.inputs[j].type;
-          methodConcat = methodConcat.concat(input,',');
-       }
+          methodConcat = methodConcat.concat(input, ',');
+        }
         input = abiMethod.inputs[abiMethod.inputs.length - 1].type;
         methodConcat += input;
       }
@@ -189,7 +190,6 @@ module.exports = {
     const expectedPrefix = web3.utils.soliditySha3(methodConcat).substring(0, 10);
 
     assert.strictEqual(expectedPrefix, callPrefix, `Expected ${methodName} callprefix is ${callPrefix} but got ${expectedPrefix}`);
-
   },
 
   getParamFromTxEvent: (
@@ -219,5 +219,5 @@ module.exports = {
     assert(typeof param !== 'undefined');
 
     return param;
-  }
+  },
 };

--- a/test/test_lib/utils.js
+++ b/test/test_lib/utils.js
@@ -167,6 +167,31 @@ module.exports = {
     return { exTxHash, exTxSignature };
   },
 
+  verifyCallPrefixConstant(methodName, callPrefix, contractName) {
+    const contract = artifacts.require(contractName);
+
+    let methodConcat = methodName.concat('(');
+    let input, abiMethod;
+
+    for(let i = 0; i < contract.abi.length; i++) {
+      abiMethod = contract.abi[i];
+      if(abiMethod.name === methodName) {
+        for(let j=0; j < abiMethod.inputs.length - 1; j ++) {
+          input = abiMethod.inputs[j].type;
+          methodConcat = methodConcat.concat(input,',');
+       }
+        input = abiMethod.inputs[abiMethod.inputs.length - 1].type;
+        methodConcat += input;
+      }
+    }
+    methodConcat = methodConcat.concat(')');
+
+    const expectedPrefix = web3.utils.soliditySha3(methodConcat).substring(0, 10);
+
+    assert.strictEqual(expectedPrefix, callPrefix, `Expected ${methodName} callprefix is ${callPrefix} but got ${expectedPrefix}`);
+
+  },
+
   getParamFromTxEvent: (
     transaction, contractAddress, eventName, paramName,
   ) => {
@@ -194,5 +219,5 @@ module.exports = {
     assert(typeof param !== 'undefined');
 
     return param;
-  },
+  }
 };

--- a/test/token_holder/execute_rule.js
+++ b/test/token_holder/execute_rule.js
@@ -20,6 +20,7 @@ const Utils = require('../test_lib/utils.js');
 const { TokenHolderUtils } = require('./utils.js');
 const { Event } = require('../test_lib/event_decoder');
 const { AccountProvider } = require('../test_lib/utils.js');
+const TokenHolder = artifacts.require('./TokenHolder.sol');
 
 const CustomRuleDouble = artifacts.require('CustomRuleDouble');
 
@@ -956,6 +957,25 @@ contract('TokenHolder::executeRule', async () => {
       assert.isOk(
         (await tokenHolder.sessionKeys.call(sessionPublicKey1)).nonce.eqn(1),
       );
+    });
+});
+
+  contract('Verify call prefix constants', async () => {
+
+    it('Verify EXECUTE_RULE_CALLPREFIX constant', async () => {
+      const tokenHolder = await TokenHolder.new();
+      const tokenHolderExecuteRuleCallPrefix = await tokenHolder.EXECUTE_RULE_CALLPREFIX();
+      const methodName = "executeRule";
+
+      Utils.verifyCallPrefixConstant(methodName, tokenHolderExecuteRuleCallPrefix, "TokenHolder");
+    });
+
+    it('Verify EXECUTE_REDEMPTION_CALLPREFIX constant', async () => {
+      const tokenHolder = await TokenHolder.new();
+      const tokenHolderExecuteRuleCallPrefix = await tokenHolder.EXECUTE_REDEMPTION_CALLPREFIX();
+      const methodName = "executeRedemption";
+
+      Utils.verifyCallPrefixConstant(methodName, tokenHolderExecuteRuleCallPrefix, "TokenHolder");
     });
   });
 });

--- a/test/token_holder/execute_rule.js
+++ b/test/token_holder/execute_rule.js
@@ -20,6 +20,7 @@ const Utils = require('../test_lib/utils.js');
 const { TokenHolderUtils } = require('./utils.js');
 const { Event } = require('../test_lib/event_decoder');
 const { AccountProvider } = require('../test_lib/utils.js');
+
 const TokenHolder = artifacts.require('./TokenHolder.sol');
 
 const CustomRuleDouble = artifacts.require('CustomRuleDouble');
@@ -958,24 +959,23 @@ contract('TokenHolder::executeRule', async () => {
         (await tokenHolder.sessionKeys.call(sessionPublicKey1)).nonce.eqn(1),
       );
     });
-});
+  });
 
   contract('Verify call prefix constants', async () => {
-
     it('Verify EXECUTE_RULE_CALLPREFIX constant', async () => {
       const tokenHolder = await TokenHolder.new();
       const tokenHolderExecuteRuleCallPrefix = await tokenHolder.EXECUTE_RULE_CALLPREFIX();
-      const methodName = "executeRule";
+      const methodName = 'executeRule';
 
-      Utils.verifyCallPrefixConstant(methodName, tokenHolderExecuteRuleCallPrefix, "TokenHolder");
+      Utils.verifyCallPrefixConstant(methodName, tokenHolderExecuteRuleCallPrefix, 'TokenHolder');
     });
 
     it('Verify EXECUTE_REDEMPTION_CALLPREFIX constant', async () => {
       const tokenHolder = await TokenHolder.new();
       const tokenHolderExecuteRuleCallPrefix = await tokenHolder.EXECUTE_REDEMPTION_CALLPREFIX();
-      const methodName = "executeRedemption";
+      const methodName = 'executeRedemption';
 
-      Utils.verifyCallPrefixConstant(methodName, tokenHolderExecuteRuleCallPrefix, "TokenHolder");
+      Utils.verifyCallPrefixConstant(methodName, tokenHolderExecuteRuleCallPrefix, 'TokenHolder');
     });
   });
 });

--- a/test/user_wallet_factory/create_user_wallet.js
+++ b/test/user_wallet_factory/create_user_wallet.js
@@ -333,13 +333,11 @@ contract('UserWalletFactory::createUserWallet', async (accounts) => {
 
   contract('Verify call prefix constants', async () => {
     it('Verify TOKENHOLDER_SETUP_CALLPREFIX constant', async () => {
-
       const userWalletFactory = await UserWalletFactory.new();
       const tokenHolderSetupCallPrefix = await userWalletFactory.TOKENHOLDER_SETUP_CALLPREFIX();
-      const methodName = "setup";
+      const methodName = 'setup';
 
-      Utils.verifyCallPrefixConstant(methodName, tokenHolderSetupCallPrefix, "TokenHolder");
-
+      Utils.verifyCallPrefixConstant(methodName, tokenHolderSetupCallPrefix, 'TokenHolder');
     });
   });
 });

--- a/test/user_wallet_factory/create_user_wallet.js
+++ b/test/user_wallet_factory/create_user_wallet.js
@@ -330,4 +330,16 @@ contract('UserWalletFactory::createUserWallet', async (accounts) => {
       });
     });
   });
+
+  contract('Verify call prefix constants', async () => {
+    it('Verify TOKENHOLDER_SETUP_CALLPREFIX constant', async () => {
+
+      const userWalletFactory = await UserWalletFactory.new();
+      const tokenHolderSetupCallPrefix = await userWalletFactory.TOKENHOLDER_SETUP_CALLPREFIX();
+      const methodName = "setup";
+
+      Utils.verifyCallPrefixConstant(methodName, tokenHolderSetupCallPrefix, "TokenHolder");
+
+    });
+  });
 });


### PR DESCRIPTION
PR contains :-
1. Test cases to verify the call prefix for `EXECUTE_REDEMPTION_CALLPREFIX`, `EXECUTE_RULE_CALLPREFIX` and `TOKENHOLDER_SETUP_CALLPREFIX`.
2. Added `verifyCallPrefixConstant` in `utils.js` which will generate the call prefix for abi and verify it with expected callprefix.

Fixes #182 